### PR TITLE
fix: appid check

### DIFF
--- a/protocol/attestation_test.go
+++ b/protocol/attestation_test.go
@@ -32,7 +32,7 @@ func TestAttestationVerify(t *testing.T) {
 			// Test Base Verification
 			err = pcc.Verify(options.Response.Challenge.String(), false, options.Response.RelyingParty.ID, options.Response.RelyingParty.Name)
 			if err != nil {
-				t.Fatalf("Not valid: %+v (%+s)", err, err.(*Error).DevInfo)
+				t.Fatalf("Not valid: %+v (%s)", err, err.(*Error).DevInfo)
 			}
 		})
 	}

--- a/protocol/authenticator.go
+++ b/protocol/authenticator.go
@@ -223,8 +223,8 @@ func (a *AuthenticatorData) Verify(rpIdHash []byte, appIDHash []byte, userVerifi
 	// Registration Step 9 & Assertion Step 11
 	// Verify that the RP ID hash in authData is indeed the SHA-256
 	// hash of the RP ID expected by the RP.
-	if !bytes.Equal(a.RPIDHash[:], rpIdHash) && appIDHash != nil && !bytes.Equal(a.RPIDHash[:], appIDHash) {
-		return ErrVerification.WithInfo(fmt.Sprintf("RP Hash mismatch. Expected %+s and Received %+s\n", a.RPIDHash, rpIdHash))
+	if !bytes.Equal(a.RPIDHash[:], rpIdHash) && !bytes.Equal(a.RPIDHash[:], appIDHash) {
+		return ErrVerification.WithInfo(fmt.Sprintf("RP Hash mismatch. Expected %s and Received %s\n", a.RPIDHash, rpIdHash))
 	}
 
 	// Registration Step 10 & Assertion Step 12

--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -202,25 +202,25 @@ func (ppkc ParsedPublicKeyCredential) GetAppID(authExt AuthenticationExtensions,
 		return "", nil
 	}
 
-	if clientValue, ok = ppkc.ClientExtensionResults["appid"]; ok {
-		if enableAppID, ok = clientValue.(bool); !ok {
-			return "", ErrBadRequest.WithDetails("Client Output appid did not have the expected type")
-		}
-
-		if !enableAppID {
-			return "", nil
-		}
-
-		if value, ok = authExt["appid"]; !ok {
-			return "", ErrBadRequest.WithDetails("Session Data does not have an appid but Client Output indicates it should be set")
-		}
-
-		if appID, ok = value.(string); !ok {
-			return "", ErrBadRequest.WithDetails("Session Data appid did not have the expected type")
-		}
-
-		return appID, nil
+	if clientValue, ok = ppkc.ClientExtensionResults["appid"]; !ok {
+		return "", nil
 	}
 
-	return "", nil
+	if enableAppID, ok = clientValue.(bool); !ok {
+		return "", ErrBadRequest.WithDetails("Client Output appid did not have the expected type")
+	}
+
+	if !enableAppID {
+		return "", nil
+	}
+
+	if value, ok = authExt["appid"]; !ok {
+		return "", ErrBadRequest.WithDetails("Session Data does not have an appid but Client Output indicates it should be set")
+	}
+
+	if appID, ok = value.(string); !ok {
+		return "", ErrBadRequest.WithDetails("Session Data appid did not have the expected type")
+	}
+
+	return appID, nil
 }


### PR DESCRIPTION
This prevents edge case checks from not matching for example when the appid hash is nil.